### PR TITLE
support glob on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "prebuild": "del dist/**/*",
+    "prebuild": "del-cli dist/**/*",
     "build": "tsc",
     "prepack": "npm run build",
     "lint": "eslint src/",

--- a/src/load.ts
+++ b/src/load.ts
@@ -29,6 +29,7 @@ import glob from 'glob'
 import { basename, resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import mappingTable from './gbcs-mapping-table.json'
+import { join } from 'node:path'
 
 export interface Template {
   fileName: string
@@ -132,8 +133,9 @@ export async function loadTemplates(
         ...(options.path
           ? [options.path]
           : [__dirname, '..', 'templates']
-        ).concat('**/*_REQUEST_DUIS.XML')
+        ).concat(join('**', '*_REQUEST_DUIS.XML'))
       ),
+      { windowsPathsNoEscape: true },
       (err, m) => (err ? r(err) : a(m))
     )
   )


### PR DESCRIPTION
Use of `glob` with `resolve` and `join` needs special attention, this PR fixes `glob` to be called from windows and work as expected.