### PR TITLE
Update with RTDS 4.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@smartdcc/duis-parser": "^0.4.0",
+        "@smartdcc/duis-parser": "^0.6.0",
         "fuse.js": "^7.0.0",
         "glob": "^10.1.0"
       },
@@ -28,6 +28,7 @@
         "eslint-config-prettier": "^9.0.0",
         "prettier": "^3.0.0",
         "ts-jest": "^29.0.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.0.2"
       },
       "engines": {
@@ -666,6 +667,28 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -1342,7 +1365,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1361,8 +1383,7 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.15",
@@ -1446,9 +1467,9 @@
       }
     },
     "node_modules/@smartdcc/duis-parser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@smartdcc/duis-parser/-/duis-parser-0.4.0.tgz",
-      "integrity": "sha512-K2o5vm/eZYSDd50XLsf1lClFiZvmiM4A60PcHfhQlnFniCUV2T/vaz+c9nf4RtxLqQIjOskWiN4m44i8ynP9ug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@smartdcc/duis-parser/-/duis-parser-0.6.0.tgz",
+      "integrity": "sha512-Nn21EIj18mtG/JtX69N8UbotQ88AOHqbOXW8ve9FH2hSOG14IzpxXt22zjfeB7pG2jwiOj1ct4GcDbRnfmimjQ==",
       "dependencies": {
         "fast-xml-parser": "^4.0.9"
       },
@@ -1464,6 +1485,24 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "16.1.1",
@@ -1958,6 +1997,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -2054,6 +2102,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2476,6 +2530,12 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2622,6 +2682,15 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -5803,6 +5872,55 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5891,6 +6009,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -6048,6 +6172,15 @@
       "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -6548,6 +6681,27 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "peer": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -7067,8 +7221,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -7081,8 +7234,7 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.15",
@@ -7154,9 +7306,9 @@
       }
     },
     "@smartdcc/duis-parser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@smartdcc/duis-parser/-/duis-parser-0.4.0.tgz",
-      "integrity": "sha512-K2o5vm/eZYSDd50XLsf1lClFiZvmiM4A60PcHfhQlnFniCUV2T/vaz+c9nf4RtxLqQIjOskWiN4m44i8ynP9ug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@smartdcc/duis-parser/-/duis-parser-0.6.0.tgz",
+      "integrity": "sha512-Nn21EIj18mtG/JtX69N8UbotQ88AOHqbOXW8ve9FH2hSOG14IzpxXt22zjfeB7pG2jwiOj1ct4GcDbRnfmimjQ==",
       "requires": {
         "fast-xml-parser": "^4.0.9"
       }
@@ -7165,6 +7317,24 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@smartdcc/duis-sign-wrap/-/duis-sign-wrap-0.1.2.tgz",
       "integrity": "sha512-75KX971ymBkNyL2e761c4HYQ4OinTCFfqW+SoCRtFC9cWm4CirKQ5CfSUp0zCFH8LcSyHhDwRL0cVtOj5NeIHg==",
+      "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@tsconfig/node16": {
@@ -7536,6 +7706,12 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "dev": true
+    },
     "aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -7600,6 +7776,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -7914,6 +8096,12 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8015,6 +8203,12 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "peer": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "29.0.0",
@@ -10338,6 +10532,35 @@
         }
       }
     },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "@tsconfig/node16": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+          "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+          "dev": true
+        }
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10391,6 +10614,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -10513,6 +10742,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsc",
     "prepack": "npm run build",
     "lint": "eslint src/",
-    "prettier-check": "prettier -c  \"src/**/*.{css,html,ts,json,md,yaml,yml}\""
+    "prettier-check": "prettier -c  \"src/**/*.{css,html,ts,json,md,yaml,yml}\"",
+    "load-templates": "(cd src ; npx ts-node -e \"import { loadTemplates } from './load' ; loadTemplates({logger: console.log}).then(x => Object.keys(x).map(k => console.log(\\`\\${k}\\\t\\${x[k].gbcs}\\\t\\${x[k].gbcsVariant}\\\t\\${x[k].info}\\`)))\")"
   },
   "repository": {
     "type": "git",
@@ -52,10 +53,11 @@
     "eslint-config-prettier": "^9.0.0",
     "prettier": "^3.0.0",
     "ts-jest": "^29.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@smartdcc/duis-parser": "^0.4.0",
+    "@smartdcc/duis-parser": "^0.6.0",
     "fuse.js": "^7.0.0",
     "glob": "^10.1.0"
   },

--- a/src/load.ts
+++ b/src/load.ts
@@ -30,6 +30,7 @@ import { basename, resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import mappingTable from './gbcs-mapping-table.json'
 import { join } from 'node:path'
+import { inspect } from 'node:util'
 
 export interface Template {
   fileName: string
@@ -97,6 +98,7 @@ export async function loadTemplate(
   const template_buffer = await readFile(fileName)
   const simplified = parseDuis('simplified', template_buffer)
   if (!isSimplifiedDuisOutputRequest(simplified)) {
+    console.log(inspect(simplified, false, 10))
     logger(`not loading duis template ${fileName} its not a request`)
     return null
   }

--- a/templates/12.2_DEVICE_PRE_NOTIFICATION_REQUEST_DUIS.XML
+++ b/templates/12.2_DEVICE_PRE_NOTIFICATION_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.13_RETURN_LOCAL_COMMAND_RESPONSE_CS06_REQUEST_DUIS.XML
+++ b/templates/8.13_RETURN_LOCAL_COMMAND_RESPONSE_CS06_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1001</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.14.1_COMMUNICATIONS_HUB_STATUS_UPDATE_INSTALL_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/8.14.1_COMMUNICATIONS_HUB_STATUS_UPDATE_INSTALL_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.14.2_COMMUNICATIONS_HUB_STATUS_UPDATE_INSTALL_NO_SM_WAN_REQUEST_DUIS.XML
+++ b/templates/8.14.2_COMMUNICATIONS_HUB_STATUS_UPDATE_INSTALL_NO_SM_WAN_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.14.3_COMMUNICATIONS_HUB_STATUS_UPDATE_FAULT_RETURN_REQUEST_DUIS.XML
+++ b/templates/8.14.3_COMMUNICATIONS_HUB_STATUS_UPDATE_FAULT_RETURN_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.14.4_COMMUNICATIONS_HUB_STATUS_UPDATE_NO_FAULT_RETURN_REQUEST_DUIS.XML
+++ b/templates/8.14.4_COMMUNICATIONS_HUB_STATUS_UPDATE_NO_FAULT_RETURN_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.2_READ_INVENTORY_REQUEST_DUIS.XML
+++ b/templates/8.2_READ_INVENTORY_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.3_DECOMMISSION_DEVICE_REQUEST_DUIS.XML
+++ b/templates/8.3_DECOMMISSION_DEVICE_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.4_UPDATE_INVENTORY_REQUEST_DUIS.XML
+++ b/templates/8.4_UPDATE_INVENTORY_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/8.6_SERVICE_OPTIN_REQUEST_DUIS.XML
+++ b/templates/8.6_SERVICE_OPTIN_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/CCS01_8.11_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CCS01_8.11_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CCS02_8.11_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CCS02_8.11_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CCS03_8.12.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CCS03_8.12.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CCS05CCS04_8.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CCS05CCS04_8.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CCS06_8.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CCS06_8.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CCS07_8.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CCS07_8.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS01a_2.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS01a_2.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:12884901888</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS01b_2.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS01b_2.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:25769803776</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02aMAC_6.24.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02aMAC_6.24.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02bACBByACB_8.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bACBByACB_8.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1005</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02bNOByNOHandover_6.21_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bNOByNOHandover_6.21_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02bNOByNO_6.15.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bNOByNO_6.15.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02bSupplierBySupplierHandover_6.21_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierBySupplierHandover_6.21_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02bSupplierBySupplier_6.15.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierBySupplier_6.15.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02bSupplierBySupplier_6.15.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierBySupplier_6.15.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02bSupplierBySupplier_6.15.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierBySupplier_6.15.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02bSupplierByTransCoS_6.23_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierByTransCoS_6.23_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1008</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02bSupplierByTransCoS_6.23_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierByTransCoS_6.23_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1007</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02bSupplierByTransCoS_6.23_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02bSupplierByTransCoS_6.23_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1006</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02c_6.17_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02c_6.17_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02d_6.15.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02d_6.15.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02e_6.24.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02e_6.24.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02fMAC_6.24.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02fMAC_6.24.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-00-00-02:00-DB-12-34-56-78-90-A0:1302</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS02gLoadControllerBySupplier_6.15.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02gLoadControllerBySupplier_6.15.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02gLoadControllerBySupplier_6.15.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02gLoadControllerBySupplier_6.15.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS02gLoadControllerBySupplier_6.15.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS02gLoadControllerBySupplier_6.15.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS03A1_8.7.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS03A1_8.7.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS03A2Critical_8.7.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS03A2Critical_8.7.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A5:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS03A2NonCritical_8.7.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS03A2NonCritical_8.7.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A4:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS03B_8.7.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS03B_8.7.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <!-- NOTE: The business originator is a Gas Import Supplier. -->
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>

--- a/templates/CS03CCritical_8.7.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS03CCritical_8.7.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <!-- NOTE: The business originator is a Gas Import Supplier. -->
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1004</sr:RequestID>

--- a/templates/CS03CNonCritical_8.7.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS03CNonCritical_8.7.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A4:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS04ACCritical_8.8.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS04ACCritical_8.8.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <!-- NOTE: The business originator is an Electricity Import Supplier. -->
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>

--- a/templates/CS04ACNonCritical_8.8.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS04ACNonCritical_8.8.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A4:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS04B_8.8.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS04B_8.8.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <!-- NOTE: The business originator is a Gas Import Supplier. -->
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>

--- a/templates/CS06_11.3_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS06_11.3_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS06_11.3_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS06_11.3_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS06_11.3_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS06_11.3_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/CS07_8.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS07_8.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <!-- NOTE: The business originator is a Gas Import Supplier. -->
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>

--- a/templates/CS08_11.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS08_11.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
-    <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A4:1000</sr:RequestID>
+    <sr:RequestID>90-B3-D5-1F-30-00-00-02:00-DB-12-34-56-78-90-A4:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>
     <sr:ServiceReference>11.2</sr:ServiceReference>
     <sr:ServiceReferenceVariant>11.2</sr:ServiceReferenceVariant>

--- a/templates/CS10a_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS10a_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS10b_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS10b_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/CS11_3.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/CS11_3.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/DBCH01_6.31_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/DBCH01_6.31_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/DBCH02_6.32_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/DBCH02_6.32_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/DBCH03_6.30_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/DBCH03_6.30_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/DBCH04_6.28_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/DBCH04_6.28_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/DBCH05_6.29_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/DBCH05_6.29_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS01a_1.1.1_CANCELLATION_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01a_1.1.1_CANCELLATION_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1009</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01a_1.1.1_FUTURE_DATED_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01a_1.1.1_FUTURE_DATED_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1008</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01a_1.1.1_IMMEDIATE_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01a_1.1.1_IMMEDIATE_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1007</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01a_1.1.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01a_1.1.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1006</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01b_1.2.1_CANCELLATION_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01b_1.2.1_CANCELLATION_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1006</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01b_1.2.1_FUTURE_DATED_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01b_1.2.1_FUTURE_DATED_TOU_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01b_1.2.1_IMMEDIATE_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01b_1.2.1_IMMEDIATE_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01b_1.2.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01b_1.2.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01c_1.1.2_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01c_1.1.2_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01c_1.1.2_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01c_1.1.2_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01c_1.1.2_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01c_1.1.2_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01d_1.2.2_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01d_1.2.2_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01d_1.2.2_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01d_1.2.2_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS01d_1.2.2_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS01d_1.2.2_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS02_1.6_CANCELLATION_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS02_1.6_CANCELLATION_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS02_1.6_FUTURE_DATED_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS02_1.6_FUTURE_DATED_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS02_1.6_IMMEDIATE_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS02_1.6_IMMEDIATE_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS03_1.6_CANCELLATION_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS03_1.6_CANCELLATION_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1012</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS03_1.6_FUTURE_DATED_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS03_1.6_FUTURE_DATED_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1011</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS03_1.6_IMMEDIATE_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS03_1.6_IMMEDIATE_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1010</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS04a_1.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS04a_1.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS04b_1.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS04b_1.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS05_1.7_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS05_1.7_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS07_2.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS07_2.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS08_2.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS08_2.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS08_2.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS08_2.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS08_2.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS08_2.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS08a_2.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS08a_2.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS08a_2.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS08a_2.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS08a_2.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS08a_2.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS09_2.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS09_2.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS10_3.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS10_3.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS12_3.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS12_3.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS14_3.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS14_3.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS15a_3.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS15a_3.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS15c_3.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS15c_3.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS16_3.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS16_3.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17a_4.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17a_4.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17b_4.1.1_DSP_FUTURE_DATED_REQUEST_DUIS.XML
+++ b/templates/ECS17b_4.1.1_DSP_FUTURE_DATED_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17b_4.1.1_REQUEST_DUIS.XML
+++ b/templates/ECS17b_4.1.1_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>2</sr:CommandVariant>

--- a/templates/ECS17b_4.1.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17b_4.1.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17b_4.1.1_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17b_4.1.1_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17c_4.16_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17c_4.16_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17d_4.1.2_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17d_4.1.2_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17d_4.1.2_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17d_4.1.2_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS17e_4.1.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS17e_4.1.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS18a_4.12.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS18a_4.12.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS18b_4.12.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS18b_4.12.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS19_4.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS19_4.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS20a_4.4.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS20a_4.4.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS20b_4.4.2_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS20b_4.4.2_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS20b_4.4.2_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS20b_4.4.2_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS20c_4.4.3_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS20c_4.4.3_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS20c_4.4.3_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS20c_4.4.3_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS20d_4.4.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS20d_4.4.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS21a_4.6.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS21a_4.6.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS21a_4.6.1_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS21a_4.6.1_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS21a_5.1._DCC_SCHEDULED_REQUEST_DUIS.XML
+++ b/templates/ECS21a_5.1._DCC_SCHEDULED_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:90-B3-D5-1F-30-00-00-02:1000</sr:RequestID>
     <sr:CommandVariant>8</sr:CommandVariant>

--- a/templates/ECS21b_4.14_KRP_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS21b_4.14_KRP_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS21b_4.14_URP_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS21b_4.14_URP_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS21c_4.6.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS21c_4.6.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS22a_4.8.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS22a_4.8.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1201</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS22b_4.8.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS22b_4.8.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS22b_4.8.1_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS22b_4.8.1_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS22c_4.8.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS22c_4.8.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS23_4.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS23_4.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS23b_4.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS23b_4.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS24_4.11.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS24_4.11.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS24b_4.11.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS24b_4.11.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25a1_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25a1_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25a2_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25a2_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25a3_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25a3_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25a_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25a_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25b3_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25b3_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25b_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25b_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25r1_6.2.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25r1_6.2.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS25r2_6.2.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS25r2_6.2.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26a_4.13_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26a_4.13_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26a_4.13_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26a_4.13_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26b_6.2.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26b_6.2.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26c_6.2.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26c_6.2.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26d_6.2.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26d_6.2.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26e_6.2.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26e_6.2.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26f_6.2.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26f_6.2.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26i_6.2.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26i_6.2.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26j_6.2.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26j_6.2.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26k_6.2.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26k_6.2.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26l_6.2.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26l_6.2.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26m_6.2.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26m_6.2.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS26n_6.2.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS26n_6.2.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS27_4.15_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS27_4.15_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS28a_6.4.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS28a_6.4.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS28a_6.4.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS28a_6.4.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS28a_6.4.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS28a_6.4.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS28b_6.4.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS28b_6.4.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS29a_6.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS29a_6.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1203</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS29b_6.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS29b_6.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1203</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS29c_6.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS29c_6.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS29d_6.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS29d_6.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS29e_6.27_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS29e_6.27_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS29f_6.27_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS29f_6.27_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS30_6.8_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS30_6.8_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS30a_6.8_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS30a_6.8_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS34_6.12_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS34_6.12_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35a_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35a_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35b_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35b_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35c_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35c_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35d_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35d_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A2:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35e_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35e_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35f_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35f_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS35g_6.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS35g_6.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS37_6.18.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS37_6.18.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1203</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS38_7.12_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS38_7.12_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS39a_6.20.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS39a_6.20.1_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS39a_6.20.1_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS39a_6.20.1_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS39b_6.20.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS39b_6.20.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS40_6.2.7_SINGLE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS40_6.2.7_SINGLE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS40_6.2.7_TWIN_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS40_6.2.7_TWIN_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS42_7.1_REQUEST_DUIS.XML
+++ b/templates/ECS42_7.1_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>7</sr:CommandVariant>

--- a/templates/ECS42_7.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS42_7.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS43_7.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS43_7.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS44_7.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS44_7.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS45_7.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS45_7.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS46a_6.14.1_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46a_6.14.1_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46a_6.14.1_SOME_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46a_6.14.1_SOME_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46c_6.14.2_CANCELLATION_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46c_6.14.2_CANCELLATION_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1008</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46c_6.14.2_FUTURE_DATED_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46c_6.14.2_FUTURE_DATED_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1007</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46c_6.14.2_IMMEDIATE_SOME_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46c_6.14.2_IMMEDIATE_SOME_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1006</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46d_6.14.3_CANCELLATION_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46d_6.14.3_CANCELLATION_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A6:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46d_6.14.3_FUTURE_DATED_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46d_6.14.3_FUTURE_DATED_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A6:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46d_6.14.3_IMMEDIATE_ALCS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46d_6.14.3_IMMEDIATE_ALCS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46d_6.14.3_IMMEDIATE_APC_INPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46d_6.14.3_IMMEDIATE_APC_INPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS46d_6.14.3_IMMEDIATE_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS46d_6.14.3_IMMEDIATE_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47Activate_7.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47Activate_7.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47Deactivate_7.6_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47Deactivate_7.6_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47Reset_7.8_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47Reset_7.8_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47a_7.13_ALCS_ACTIVATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47a_7.13_ALCS_ACTIVATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47a_7.13_ALCS_DEACTIVATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47a_7.13_ALCS_DEACTIVATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47a_7.13_APC_INPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47a_7.13_APC_INPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47a_7.13_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47a_7.13_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47e_7.16_APC_INPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47e_7.16_APC_INPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-08:00-DB-12-34-56-78-90-A0:9001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS47e_7.16_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS47e_7.16_APC_OUTPUT_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-08:00-DB-12-34-56-78-90-A0:9002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS48_6.26_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS48_6.26_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS50_9.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS50_9.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS52_11.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS52_11.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS57_6.18.2_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS57_6.18.2_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS57_6.18.2_SOME_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS57_6.18.2_SOME_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A0:1201</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS61a_7.7_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS61a_7.7_ALL_OPTIONALS_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS61c_7.11_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS61c_7.11_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS61d_7.14_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS61d_7.14_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS61e_7.15_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS61e_7.15_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS62Add_7.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS62Add_7.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS62Remove_7.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS62Remove_7.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS66_4.17_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS66_4.17_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/ECS70Commission_8.1.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS70Commission_8.1.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS70_6.11_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS70_6.11_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS81_6.25_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS81_6.25_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/ECS82_4.18_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/ECS82_4.18_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A0:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS01a_1.1.1_CANCELLATION_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS01a_1.1.1_CANCELLATION_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1006</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS01a_1.1.1_FUTURE_DATED_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS01a_1.1.1_FUTURE_DATED_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS01a_1.1.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS01a_1.1.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1007</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS01b_1.2.1_CANCELLATION_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS01b_1.2.1_CANCELLATION_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS01b_1.2.1_FUTURE_DATED_BLOCK_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS01b_1.2.1_FUTURE_DATED_BLOCK_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS01b_1.2.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS01b_1.2.1_IMMEDIATE_TOU_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS02_1.6_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS02_1.6_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS02_1.6_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS02_1.6_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS02_1.6_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS02_1.6_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS03_1.6_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS03_1.6_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1006</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS03_1.6_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS03_1.6_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1005</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS03_1.6_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS03_1.6_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS04_2.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS04_2.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS05_2.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS05_2.1_CANCELLATION_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS05_2.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS05_2.1_FUTURE_DATED_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS05_2.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS05_2.1_IMMEDIATE_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS06_2.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS06_2.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS07_3.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS07_3.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS09_3.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS09_3.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS11_3.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS11_3.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13a_4.1.1_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
+++ b/templates/GCS13a_4.1.1_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13a_4.1.1_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
+++ b/templates/GCS13a_4.1.1_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13a_4.1.1_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
+++ b/templates/GCS13a_4.1.1_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13b_4.1.4_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
+++ b/templates/GCS13b_4.1.4_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13b_4.1.4_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
+++ b/templates/GCS13b_4.1.4_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13b_4.1.4_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
+++ b/templates/GCS13b_4.1.4_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13c_4.1.2_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
+++ b/templates/GCS13c_4.1.2_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13c_4.1.2_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
+++ b/templates/GCS13c_4.1.2_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS13c_4.1.2_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
+++ b/templates/GCS13c_4.1.2_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS14_4.3_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
+++ b/templates/GCS14_4.3_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS14_4.3_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
+++ b/templates/GCS14_4.3_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS14_4.3_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
+++ b/templates/GCS14_4.3_SUCCESS_UNRELIABLE_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS15b_4.4.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS15b_4.4.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1006</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS15c_4.4.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS15c_4.4.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1003</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS15d_4.4.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS15d_4.4.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS15e_4.4.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS15e_4.4.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS16a_4.6.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS16a_4.6.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1004</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS16b_4.14_KRP_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS16b_4.14_KRP_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1006</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS16b_4.14_URP_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS16b_4.14_URP_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-03-00-00:00-DB-12-34-56-78-90-A3:1100</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS17_4.8.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS17_4.8.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS18_4.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS18_4.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS20_6.22_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS20_6.22_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS20r_6.2.10_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS20r_6.2.10_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21a_6.2.8_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21a_6.2.8_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21b_4.13_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21b_4.13_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21d_6.2.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21d_6.2.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21e_6.2.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21e_6.2.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21f_4.11.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21f_4.11.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21j_6.2.9_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21j_6.2.9_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21k_6.2.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21k_6.2.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS21m_6.2.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS21m_6.2.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS23_6.6_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS23_6.6_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS24_6.7_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS24_6.7_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS24a_6.7_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS24a_6.7_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS25_6.8_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS25_6.8_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1002</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS25a_6.8_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS25a_6.8_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1004</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS28Commission_8.1.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS28Commission_8.1.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS28_6.11_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS28_6.11_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS31_14.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS31_14.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-02-00-00:00-DB-12-34-56-78-90-A1:1200</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS32_7.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS32_7.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS33_7.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS33_7.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS36_9.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS36_9.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS38_11.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS38_11.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS39_7.3_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS39_7.3_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS40a_1.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS40a_1.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS40b_1.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS40b_1.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS40c_1.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS40c_1.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1003</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS40d_1.5_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS40d_1.5_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>4</sr:CommandVariant>

--- a/templates/GCS41_6.20.1_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS41_6.20.1_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS44_3.4_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS44_3.4_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS46_6.2.7_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS46_6.2.7_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS59_8.12.2_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS59_8.12.2_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-00-00-02:00-DB-12-34-56-78-90-A3:1300</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS60_4.18_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS60_4.18_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS60a_4.18_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
+++ b/templates/GCS60a_4.18_SUCCESS_RELIABLE_GPF_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS60a_4.18_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
+++ b/templates/GCS60a_4.18_SUCCESS_RELIABLE_GSME_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1000</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS60a_4.18_SUCCESS_UNRELIABLE_GSME_REQUEST_DUIS.XML
+++ b/templates/GCS60a_4.18_SUCCESS_UNRELIABLE_GSME_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A1:1001</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>

--- a/templates/GCS61_4.17_SUCCESS_REQUEST_DUIS.XML
+++ b/templates/GCS61_4.17_SUCCESS_REQUEST_DUIS.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.1">
+<sr:Request xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sr="http://www.dccinterface.co.uk/ServiceUserGateway" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="5.2">
   <sr:Header>
     <sr:RequestID>90-B3-D5-1F-30-01-00-00:00-DB-12-34-56-78-90-A3:1003</sr:RequestID>
     <sr:CommandVariant>1</sr:CommandVariant>


### PR DESCRIPTION
Replace templates from RTDS 4.3.0 with RTDS 4.6.0

Minor change as most templates remain the same.

While implementing, identified upstream issue (SmartDCCInnovation/duis-parser#430) which prevented CS02a/CS02f from being correctly loaded.